### PR TITLE
Add zoomgov domains

### DIFF
--- a/background.js
+++ b/background.js
@@ -21,4 +21,4 @@ chrome.webRequest.onBeforeRequest.addListener(function(details) {
   return {
     redirectUrl: url.href
   };
-}, { urls: ['*://*.zoom.us/j/*', '*://*.zoom.us/s/*'] }, ['blocking']);
+}, { urls: ['*://*.zoom.us/j/*', '*://*.zoom.us/s/*', '*://*.zoomgov.com/j/*', '*://*.zoomgov.com/s/*'] }, ['blocking']);

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "*://*.zoom.us/*"
+    "*://*.zoom.us/*",
+    "*://*.zoomgov.com/*"
   ],
   "background": {
     "scripts": [


### PR DESCRIPTION
Zoom for Government or ZoomGov uses slightly different domains. This PR adds that domain to `urls` so that they are also redirected